### PR TITLE
prepare v2.0.1

### DIFF
--- a/src/lib/anime/renamer.ts
+++ b/src/lib/anime/renamer.ts
@@ -475,8 +475,12 @@ export class AnimeRenamer {
 
     // update hashes
     if (!dryRun) {
-      this.hashCache[episode.destination_path] = this.hashCache[episode.path];
+      // update link in ed2hash
+      const ed2hash = this.hashCache[episode.path];
+      ed2hash.link = `ed2k://|file|${path.basename(episode.destination_path)}|${ed2hash.size}|${ed2hash.hash}|/`;
+
       delete this.hashCache[episode.path];
+      this.hashCache[episode.destination_path] = ed2hash;
       this.writeHashCache();
     }
 

--- a/src/vars.ts
+++ b/src/vars.ts
@@ -1,4 +1,4 @@
 export const _DEFINE_PROG: string = "akiba";
-export const _DEFINE_VER: string = "2.0.0";
+export const _DEFINE_VER: string = "2.0.1";
 
 // vim: tabstop=2 shiftwidth=2 softtabstop=0 smarttab expandtab


### PR DESCRIPTION
- added a `--dry-run` flag to rename
- fixed ed2khash links after rename, we update the path for the cache but did not update the embedded filename in the link
- fixed formatter generating invalid file names